### PR TITLE
Allow for registry authentication

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,6 +5,8 @@ version: 2.0.2
 readme: README.md
 authors:
   - Ansible
+dependencies:
+  "containers.podman": ">=1.10.2"
 description: Receptor installer
 license_file: LICENSE
 tags:

--- a/roles/setup/defaults/main.yml
+++ b/roles/setup/defaults/main.yml
@@ -67,8 +67,3 @@ python_executable: python3
 minimum_python_version: 3.9
 
 receptor_packages: []
-
-receptor_image_name: quay.io/ansible/awx-ee
-receptor_image_tag: latest
-receptor_image_authfile: ''
-awx_isolation_base_path: /tmp

--- a/roles/setup/tasks/setup-container.yml
+++ b/roles/setup/tasks/setup-container.yml
@@ -60,6 +60,7 @@
             group: "{{ receptor_group }}"
             mode: '0644'
 
+        # Username and password are required values, but authentication is managed through the authfile
         - name: Login to registry with authfile
           when: receptor_image_authfile_path is defined
           containers.podman.podman_login:
@@ -68,6 +69,8 @@
             username: ''
             password: ''
 
+    # Using command module instead of podman_image module here,
+    # as the podman_image module does not yet support pulling by digest
     - name: Pull the latest release of receptor
       ansible.builtin.command:
         cmd: "podman pull {{ receptor_image_with_digest }}"

--- a/roles/setup/tasks/setup-container.yml
+++ b/roles/setup/tasks/setup-container.yml
@@ -22,10 +22,22 @@
     receptor_uid_directory: "/run/user/{{ receptor_user_register.uid }}"
     receptor_image_with_digest: "{{ receptor_image_registry }}/{{ receptor_image_name }}@{{ receptor_image_sha }}"
   block:
+    - name: Set facts
+      ansible.builtin.set_fact:
+        user_home_directory: "/home/{{ receptor_user }}"
+
     - name: Create containers.conf file
       ansible.builtin.template:
         src: templates/containers.conf.j2
         dest: ~/.config/containers/containers.conf
+        mode: '0750'
+        owner: "{{ receptor_user }}"
+        group: "{{ receptor_group }}"
+
+    - name: Copy podman alias script
+      ansible.builtin.template:
+        src: templates/podman_alias.sh.j2
+        dest: "{{ user_home_directory }}/.ansible/podman"
         mode: '0750'
         owner: "{{ receptor_user }}"
         group: "{{ receptor_group }}"
@@ -90,6 +102,7 @@
           - "{{ receptor_ca_certfile }}:{{ receptor_ca_certfile }}:ro"
           - "{{ receptor_socket_dir }}:{{ receptor_socket_dir }}:z"
           - "{{ receptor_uid_directory }}/podman/podman.sock:/run/podman/podman.sock:z"
+          - "{{ user_home_directory }}/.ansible/podman:/usr/bin/podman:ro,z"
           - "{{ awx_isolation_base_path }}:{{ awx_isolation_base_path }}"
         privileged: true
         security_opt:

--- a/roles/setup/tasks/setup-container.yml
+++ b/roles/setup/tasks/setup-container.yml
@@ -20,7 +20,16 @@
     XDG_RUNTIME_DIR: "/run/user/{{ receptor_user_register.uid }}"
   vars:
     receptor_uid_directory: "/run/user/{{ receptor_user_register.uid }}"
+    receptor_image_with_digest: "{{ receptor_image_registry }}/{{ receptor_image_name }}@{{ receptor_image_sha }}"
   block:
+    - name: Create containers.conf file
+      ansible.builtin.template:
+        src: templates/containers.conf.j2
+        dest: ~/.config/containers/containers.conf
+        mode: '0750'
+        owner: "{{ receptor_user }}"
+        group: "{{ receptor_group }}"
+
     - name: Enable podman socket
       ansible.builtin.systemd:
         name: podman.socket
@@ -28,17 +37,42 @@
         enabled: true
         scope: user
 
+    - name: Login to registry if authentication is provided
+      when: (receptor_image_registry_username is defined and receptor_image_registry_token is defined) or receptor_image_authfile_path is defined
+      block:
+        - name: Login to registry with username and token
+          when: receptor_image_registry_username is defined and receptor_image_registry_token is defined
+          containers.podman.podman_login:
+            username: "{{ receptor_image_registry_username }}"
+            password: "{{ receptor_image_registry_token }}"
+            registry: "{{ receptor_image_registry }}"
+
+        - name: Copy authfile with owner and permissions
+          when: receptor_image_authfile_path is defined
+          ansible.builtin.copy:
+            src: "{{ receptor_image_authfile_path }}"
+            dest: ~/.config/containers/auth.json
+            owner: "{{ receptor_user }}"
+            group: "{{ receptor_group }}"
+            mode: '0644'
+
+        - name: Login to registry with authfile
+          when: receptor_image_authfile_path is defined
+          containers.podman.podman_login:
+            authfile: ~/.config/containers/auth.json
+            registry: "{{ receptor_image_registry }}"
+            username: ''
+            password: ''
+
     - name: Pull the latest release of receptor
-      containers.podman.podman_image:
-        name: "{{ receptor_image_name }}"
-        tag: "{{ receptor_image_tag }}"
-        auth_file: "{{ lookup('ansible.builtin.file', receptor_image_authfile, errors='ignore') }}"
-        state: present
+      ansible.builtin.command:
+        cmd: "podman pull {{ receptor_image_with_digest }}"
+      changed_when: false
 
     - name: Run receptor image
       containers.podman.podman_container:
         name: "{{ receptor_service_name }}"
-        image: "{{ receptor_image_name }}:{{ receptor_image_tag }}"
+        image: "{{ receptor_image_with_digest }}"
         recreate: true
         state: present
         network: host

--- a/roles/setup/tasks/setup-container.yml
+++ b/roles/setup/tasks/setup-container.yml
@@ -69,12 +69,10 @@
             username: ''
             password: ''
 
-    # Using command module instead of podman_image module here,
-    # as the podman_image module does not yet support pulling by digest
-    - name: Pull the latest release of receptor
-      ansible.builtin.command:
-        cmd: "podman pull {{ receptor_image_with_digest }}"
-      changed_when: false
+    - name: Pull the latest release of receptor by digest
+      containers.podman.podman_image:
+        name: "{{ receptor_image_with_digest }}"
+        state: present
 
     - name: Run receptor image
       containers.podman.podman_container:

--- a/roles/setup/tasks/setup-container.yml
+++ b/roles/setup/tasks/setup-container.yml
@@ -34,14 +34,6 @@
         owner: "{{ receptor_user }}"
         group: "{{ receptor_group }}"
 
-    - name: Copy podman alias script
-      ansible.builtin.template:
-        src: templates/podman_alias.sh.j2
-        dest: "{{ user_home_directory }}/.ansible/podman"
-        mode: '0750'
-        owner: "{{ receptor_user }}"
-        group: "{{ receptor_group }}"
-
     - name: Enable podman socket
       ansible.builtin.systemd:
         name: podman.socket
@@ -102,7 +94,6 @@
           - "{{ receptor_ca_certfile }}:{{ receptor_ca_certfile }}:ro"
           - "{{ receptor_socket_dir }}:{{ receptor_socket_dir }}:z"
           - "{{ receptor_uid_directory }}/podman/podman.sock:/run/podman/podman.sock:z"
-          - "{{ user_home_directory }}/.ansible/podman:/usr/bin/podman:ro,z"
           - "{{ awx_isolation_base_path }}:{{ awx_isolation_base_path }}"
         privileged: true
         security_opt:

--- a/roles/setup/templates/containers.conf.j2
+++ b/roles/setup/templates/containers.conf.j2
@@ -1,1 +1,2 @@
+[engine]
 network_cmd_options=["cidr={{ podman_internal_cidr }}"]

--- a/roles/setup/templates/containers.conf.j2
+++ b/roles/setup/templates/containers.conf.j2
@@ -1,0 +1,1 @@
+network_cmd_options=["cidr={{ podman_internal_cidr }}"]

--- a/roles/setup/templates/podman_alias.sh.j2
+++ b/roles/setup/templates/podman_alias.sh.j2
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec /usr/bin/podman-remote "$@"

--- a/roles/setup/templates/podman_alias.sh.j2
+++ b/roles/setup/templates/podman_alias.sh.j2
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /usr/bin/podman-remote "$@"


### PR DESCRIPTION
Allow for registry authentication to be provided in the form of an auth file or username/password.

Also allowing for a custom podman CIDR range to be specified. 